### PR TITLE
add docker CI and publish action

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,19 @@
+name: Docker CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: |
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          IMAGE_TAG=ghcr.io/${{ github.repository }}:${COMMIT_HASH}
+          docker build . --file Dockerfile --tag $IMAGE_TAG

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,36 @@
+name: Docker publish
+
+on:
+  release:
+    types: [ created ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for image tag
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust CI
 
 on:
   push:


### PR DESCRIPTION
If a new release is created via the [Github UI](https://github.com/rolling-stock-scheduling/rssched-solver/releases) then a docker image will be built and published to GHCR.

I think we should release a version to mark the end of the second phase and to make the docker image easily available.